### PR TITLE
support multiple clients

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+
+[run]
+omit =
+	android_resources_checker/app.py
+	android_resources_checker/reporting.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # CHANGELOG
 
 ## [UNRELEASED]
+
 - Add inspection to resources declared as entries (`string`, `color`, `dimen`)
+- Renamed `--app-path` to `--app`
+- Renamed `--client-path` to `--client`  
+- Add ability to provide multiple clients.
+    * This is done via the `--client` flag; you should use one for each of the clients.
 
 ## Version 0.0.3
 **2021-03-29**

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install -U android-resources-checker
 Imagining your app in the project `subject-app`, you can trigger the resources inspection by running:
 
 ```shell
-android-resources-checker --app-path /path/to/subject-app
+android-resources-checker --app /path/to/subject-app
 ```
 
 ## Inspecting your library app resources.
@@ -45,8 +45,9 @@ resources of the library app by running:
 
 ```shell
 android-resources-checker \
-  --app-path /path/to/lib-app \
-  --client-path /path/to/client-app
+  --app /path/to/lib-app \
+  --client /path/to/client-app-1 \
+  --client /path/to/client-app-2
 ```
 
 An example of a run could look like this:

--- a/android_resources_checker/app.py
+++ b/android_resources_checker/app.py
@@ -9,8 +9,8 @@ class Application(object):
         self.analyzer = analyzer
         self.reporter = reporter
 
-    def execute(self, app_path, client_app_path=None):
-        self.reporter.apps(client_app_path, app_path)
+    def execute(self, app_path, clients=None):
+        self.reporter.apps(app_path, clients)
 
         app_name = app_path.split("/")[-1]
 
@@ -25,11 +25,10 @@ class Application(object):
 
             usage_references = self.resources_fetcher.fetch_used_resources(app_path)
             console.log(f"{app_name} - used resources processed!")
-
-            if client_app_path is not None:
-                client_app_name = client_app_path.split("/")[-1]
+            for client in clients:
+                client_app_name = client.split("/")[-1]
                 usage_references = usage_references.union(
-                    self.resources_fetcher.fetch_used_resources(client_app_path)
+                    self.resources_fetcher.fetch_used_resources(client)
                 )
                 console.log(f"{client_app_name} - used resources processed!")
 

--- a/android_resources_checker/entrypoint.py
+++ b/android_resources_checker/entrypoint.py
@@ -21,26 +21,27 @@ CLIENT_PROJECT_HELP = (
 
 @click.command()
 @click.option(
-    "--app-path",
+    "--app",
     type=click.Path(resolve_path=True, exists=True, file_okay=False),
     required=True,
     help=LIB_PROJECT_HELP,
 )
 @click.option(
-    "--client-path",
+    "--client",
     type=click.Path(resolve_path=True, exists=True, file_okay=True),
+    multiple=True,
     required=False,
     help=CLIENT_PROJECT_HELP,
 )
-def launch(app_path, client_path):
+def launch(app, client):
     try:
-        app = Application(
+        application = Application(
             resources_fetcher=ResourcesFetcher(FilesHandler()),
             resources_modifier=ResourcesModifier(),
             analyzer=ResourcesAnalyzer(),
             reporter=Reporter(console=Console()),
         )
-        app.execute(app_path=app_path, client_app_path=client_path)
+        application.execute(app_path=app, clients=client)
         sys.exit(0)
     except Exception:
         logging.exception("Could not complete analysis.")

--- a/android_resources_checker/reporting.py
+++ b/android_resources_checker/reporting.py
@@ -23,8 +23,8 @@ class Reporter:
         self.console = console
         self.output_delegate = StdoutReporter(console)
 
-    def apps(self, client_app_path, lib_app_path):
-        self.output_delegate.apps(client_app_path, lib_app_path)
+    def apps(self, lib_app_path, clients):
+        self.output_delegate.apps(lib_app_path, clients)
 
     def deletion_completed(self, num_resources):
         self.console.print(f"{num_resources} resources deleted! :rocket:")
@@ -43,10 +43,10 @@ class ContextReporter:
     def __init__(self, console):
         self.console = console
 
-    def apps(self, client_app_path, lib_app_path):
+    def apps(self, lib_app_path, clients):
         self.__print("Reference app", lib_app_path, "cyan")
-        if client_app_path is not None:
-            self.__print("Client app", client_app_path, "cyan")
+        for client in clients:
+            self.__print("Client app", client, "cyan")
 
     def __print(self, prefix, content, color):
         printer = self.console


### PR DESCRIPTION
## What 

- Renamed `--app-path` to `--app`
- Renamed `--client-path` to `--client`  
- Add ability to provide multiple clients.
    * This is done via the `--client` flag; you should use one for each of the clients.